### PR TITLE
Anpassung damit Filter funktionieren.

### DIFF
--- a/frappe/public/js/frappe/form/controls/autocomplete.js
+++ b/frappe/public/js/frappe/form/controls/autocomplete.js
@@ -100,7 +100,13 @@ frappe.ui.form.ControlAutocomplete = frappe.ui.form.ControlData.extend({
 	},
 
 	validate(value) {
+		if (this.df.ignore_validation) {
+			return value || '';
+		}
 		let valid_values = this.awesomplete._list.map(d => d.value);
+		if (!valid_values.length) {
+			return value;
+		}
 		if (valid_values.includes(value)) {
 			return value;
 		} else {


### PR DESCRIPTION
Die Filter werden nicht korrekt gesetzt wenn ein Feld mit "in" oder "not in" gesetzt ist. 
Der Fehler liegt in der autocomplete.js und wurde in der aktuellsten V12 Version vom frappe team behoben. 