### PR TITLE
Improvement: Allow custom page sizes in print formats via CSS

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -125,9 +125,10 @@ def read_options_from_html(html):
 	toggle_visible_pdf(soup)
 
 	# use regex instead of soup-parser
-	for attr in ("margin-top", "margin-bottom", "margin-left", "margin-right", "page-size", "header-spacing"):
+	for attr in ("margin-top", "margin-bottom", "margin-left", "margin-right", "page-size", "page-width", "page-height", "header-spacing"):
 		try:
-			pattern = re.compile(r"(\.print-format)([\S|\s][^}]*?)(" + str(attr) + r":)(.+)(mm;)")
+			ending = "(;)" if attr == "page-size" else "(mm;)"
+			pattern = re.compile(r"(\.print-format)([\S|\s][^}]*?)(" + str(attr) + r":)(.+)" + ending)
 			match = pattern.findall(html)
 			if match:
 				options[attr] = str(match[-1][3]).strip()


### PR DESCRIPTION
Führt die Möglichkeit ein, im CSS des Druckformates die Seitengrösse in mm anzugeben, welche dann an wkhtmltopdf übergeben wird. So können auch für Etikettendrucker die normalen Frappe-Druckformate verwendet werden.