### PR TITLE
Add PDF export option to reports (other than query reports)

### DIFF
--- a/frappe/public/html/print_template.html
+++ b/frappe/public/html/print_template.html
@@ -20,7 +20,7 @@
 			<div id="footer-html" class="visible-pdf">
 				{% if print_settings.letter_head && print_settings.letter_head.footer %}
 					<div class="letter-head-footer">
-						{{ print_settings.letter_head.footer }}
+						{{ print_settings.letter_head.footer.replace("{today}", frappe.datetime.obj_to_user(frappe.datetime.get_today())) }}
 					</div>
 				{% endif %}
 				<p class="text-center small page-number visible-pdf">
@@ -36,7 +36,7 @@
 			>
 			  {% if print_settings.letter_head %}
 			  <div {% if print_settings.repeat_header_footer %} id="header-html" class="hidden-pdf" {% endif %}>
-				  <div class="letter-head">{{ print_settings.letter_head.header }}</div>
+				  <div class="letter-head">{{ print_settings.letter_head.header.replace("{today}", frappe.datetime.obj_to_user(frappe.datetime.get_today())) }}</div>
 			  </div>
 			  {% endif %}
 	        {{ content }}

--- a/frappe/public/js/frappe/form/print.js
+++ b/frappe/public/js/frappe/form/print.js
@@ -480,7 +480,8 @@ frappe.ui.get_print_settings = function (pdf, callback, letter_head, pick_column
 	var columns = [{
 		fieldtype: "Check",
 		fieldname: "with_letter_head",
-		label: __("With Letter head")
+		label: __("With Letter head"),
+		default: letter_head ? true : false
 	}, {
 		fieldtype: "Select",
 		fieldname: "letter_head",

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1220,7 +1220,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 
 						frappe.render_pdf(html, print_settings);
 
-					}, this.report_doc.letter_head);
+					}, (this.report_doc ? this.report_doc.letter_head : false));
 				}
 			},
 			{

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1181,6 +1181,49 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				}
 			},
 			{
+				label: __('PDF'),
+				action: () => {
+					const rows_in_order = this.datatable.datamanager.rowViewOrder.map(index => {
+						if (this.datatable.bodyRenderer.visibleRowIndices.includes(index)) {
+							return this.data[index];
+						}
+					}).filter(Boolean);
+
+					if (this.add_totals_row) {
+						const total_data = this.get_columns_totals(this.data);
+						total_data['name'] = __('Totals').bold();
+						rows_in_order.push(total_data);
+					}
+
+					let dialog = frappe.ui.get_print_settings(false, print_settings => {
+						var title =  this.report_name || __(this.doctype);
+
+						const content = frappe.render_template('print_grid', {
+							title: title,
+							subtitle: this.get_filters_html_for_print(),
+							filters: this.filters,
+							data: rows_in_order,
+							original_data: this.data,
+							columns: this.columns,
+							report: this
+						});
+
+						const html = frappe.render_template('print_template', {
+							title: title,
+							content: content,
+							base_url: frappe.urllib.get_base_url(),
+							print_css: frappe.boot.print_css,
+							print_settings: print_settings,
+							landscape: (print_settings.orientation == 'Landscape'),
+							columns: this.columns
+						});
+
+						frappe.render_pdf(html, print_settings);
+
+					}, this.report_doc.letter_head);
+				}
+			},
+			{
 				label: __('Toggle Chart'),
 				action: () => this.toggle_charts()
 			},


### PR DESCRIPTION
Inserted code adapted from query_report.js into report_view.js to allow for creating a PDF document from any report, including user-defined reports. Also added the option of using a placeholder ("{today}") in report-specific letter heads (header and footer part), which will be replaced by today's date when a report is exported.