### PR TITLE
get_pdf: Retrieve smart shrinking option even when a default print format is used

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -8,6 +8,7 @@ from frappe import _
 import six, re, io
 from bs4 import BeautifulSoup
 from PyPDF2 import PdfFileReader, PdfFileWriter
+from frappe.www.printview import get_print_format_doc
 
 def get_pdf(html, options=None, output=None, print_format=None):
 	html = scrub_urls(html)
@@ -17,16 +18,16 @@ def get_pdf(html, options=None, output=None, print_format=None):
 		"disable-javascript": "",
 		"disable-local-file-access": "",
 	})
-    
+	
 	# add options from print format
-	if print_format and frappe.db.exists("Print Format", print_format):
-		pf = frappe.get_doc("Print Format", print_format)
-		if cint(pf.disable_smart_shrinking) == 1:
+	print_format_doc = get_print_format_doc(print_format, frappe.get_meta(frappe.form_dict.doctype))
+	if print_format_doc:
+		if cint(print_format_doc.disable_smart_shrinking) == 1:
 			options.update({
 				"disable-smart-shrinking": ""
 			})
+	
 	filedata = ''
-
 	try:
 		# Set filename property to false, so no file is actually created
 		filedata = pdfkit.from_string(html, False, options=options or {})


### PR DESCRIPTION
Use the frappe.www.printview.get_print_format_doc function, which can find the appropriate print format from metadata even if it is not given as a parameter.
This prevents a wrong setting for the "disable smart shrinking" parameter, e.g. when retrieving PDF prints of documents using their default print formats.