### PR TITLE
Check is route a external link, when yes open a new window.

### DIFF
--- a/frappe/public/js/frappe/views/components/ModuleLinkItem.vue
+++ b/frappe/public/js/frappe/views/components/ModuleLinkItem.vue
@@ -67,6 +67,8 @@ export default {
 		handle_click(e) {
 			if (this.youtube_id) {
 				frappe.help.show_video(this.youtube_id);
+			} else if (this.route && /^https?:\/\//.test(this.route)) {
+				window.open(this.route, "_blank");
 			} else {
 				frappe.set_route(this.route);
 			}


### PR DESCRIPTION
When the route of a item is set to an external http or https address open a new windows and follow the link. 
